### PR TITLE
Use public_ip instead of eip and add option to name AWS VPN tunnels.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_customer_gateway" "transit_gw" {
   bgp_asn    = var.aviatrix_asn
-  ip_address = var.gw_object.eip
+  ip_address = var.gw_object.public_ip
   type       = "ipsec.1"
 
   tags = {
@@ -11,7 +11,7 @@ resource "aws_customer_gateway" "transit_gw" {
 resource "aws_customer_gateway" "transit_ha_gw" {
   count      = local.is_ha ? 1 : 0
   bgp_asn    = var.aviatrix_asn
-  ip_address = var.gw_object.ha_eip
+  ip_address = var.gw_object.ha_public_ip
   type       = "ipsec.1"
 
   tags = {
@@ -35,6 +35,7 @@ resource "aws_vpn_connection" "transit_gw" {
   tunnel2_inside_cidr   = var.tunnel_cidrs[1]
   tunnel1_preshared_key = random_password.psk[0].result
   tunnel2_preshared_key = random_password.psk[1].result
+  tags                  = { Name = "${var.aws_vpn_tunnel_name}" }
 }
 
 resource "aws_vpn_connection" "transit_ha_gw" {
@@ -47,6 +48,7 @@ resource "aws_vpn_connection" "transit_ha_gw" {
   tunnel2_inside_cidr   = var.tunnel_cidrs[3]
   tunnel1_preshared_key = random_password.psk[0].result
   tunnel2_preshared_key = random_password.psk[1].result
+  tags                  = { Name = "${var.aws_vpn_ha_tunnel_name}" }
 }
 
 resource "aviatrix_transit_external_device_conn" "tunnel1_to_tgw" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,18 @@ variable "approved_cidrs" {
   default     = null
 }
 
+variable "aws_vpn_tunnel_name" {
+  description = "Name of AWS S2S VPN tunnel."
+  type        = string
+  default     = "-"
+}
+
+variable "aws_vpn_ha_tunnel_name" {
+  description = "Name of AWS S2S VPN high availability tunnel."
+  type        = string
+  default     = "-"
+}
+
 locals {
   is_ha           = var.gw_object.ha_gw_size != null
   connection_name = length(var.connection_name) > 0 ? var.connection_name : "${var.gw_object.gw_name}_to_tgw"


### PR DESCRIPTION
Fixes issues with referencing `eip`.

Also adds option for the user to name the AWS S2C VPN tunnel